### PR TITLE
Add Coder version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # coder-infra
 
+[![Coder Version](https://img.shields.io/badge/coder-v2.31.7-blue)](https://github.com/coder/coder/releases/tag/v2.31.7)
+
 Self-hosted AI coding agents on a EUR 15/month VPS. Fire tasks, close the lid, review PRs.
 
 An open-source reference setup for running [Coder](https://coder.com) + [Claude Code](https://claude.ai/claude-code) on Hetzner with [Tailscale](https://tailscale.com) zero-trust networking.


### PR DESCRIPTION
## Summary

- Adds a shields.io static badge at the top of `README.md` showing the Coder version
- Version (`v2.31.7`) is sourced from `coder_image` in `ansible/group_vars/all.yml`
- Badge links to the corresponding GitHub release page

Closes #14

## Test plan

- [ ] Verify badge renders correctly in the README preview on GitHub
- [ ] Confirm the version string matches `coder_image` in `ansible/group_vars/all.yml`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)